### PR TITLE
Check for aspell in PATH

### DIFF
--- a/lib/aspelllint.rb
+++ b/lib/aspelllint.rb
@@ -88,24 +88,12 @@ module Aspelllint
     t.write(contents)
     t.close
 
-    filename = t.path
-
-    output = `sed 's/#/ /g' "#{filename}" 2>&1 | aspell -a -c 2>&1`
-
-    if output =~ /aspell\: command not found/m
-      puts 'aspell: command not found'
-    else
-      lines = output.split("\n").select { |line| line =~ /^\&\s.+$/ }
-
-      misspellings = lines.map { |line| Misspelling.parse('stdin', line) }
-
-      misspellings.each { |m| puts m }
-
-      t.delete
-    end
+    check(t.path, 'stdin')
+  ensure
+    t.delete
   end
 
-  def self.check(filename)
+  def self.check(filename, original_name = filename)
     output = `sed 's/#/ /g' "#{filename}" 2>&1 | aspell -a -c 2>&1`
 
     if output =~ /aspell\: command not found/m
@@ -113,7 +101,7 @@ module Aspelllint
     else
       lines = output.split("\n").select { |line| line =~ /^\&\s.+$/ }
 
-      misspellings = lines.map { |line| Misspelling.parse(filename, line) }
+      misspellings = lines.map { |line| Misspelling.parse(original_name, line) }
 
       misspellings.each { |m| puts m }
     end

--- a/lib/aspelllint.rb
+++ b/lib/aspelllint.rb
@@ -3,6 +3,7 @@ require_relative 'cli'
 
 require 'ptools'
 require 'tempfile'
+require 'English'
 
 DEFAULT_IGNORES = %w(
   .hg
@@ -93,17 +94,19 @@ module Aspelllint
     t.delete
   end
 
-  def self.check(filename, original_name = filename)
-    output = `sed 's/#/ /g' "#{filename}" 2>&1 | aspell -a -c 2>&1`
-
-    if output =~ /aspell\: command not found/m
-      puts 'aspell: command not found'
-    else
-      lines = output.split("\n").select { |line| line =~ /^\&\s.+$/ }
-
-      misspellings = lines.map { |line| Misspelling.parse(original_name, line) }
-
-      misspellings.each { |m| puts m }
+  def self.executable_in_path?(name)
+    ENV['PATH'].split(File::PATH_SEPARATOR).any? do |path|
+      File.executable?(File.join(path, name))
     end
+  end
+
+  def self.check(filename, original_name = filename)
+    fail 'aspell not found in PATH' unless executable_in_path?('aspell')
+    output = `sed 's/#/ /g' "#{filename}" 2>&1 | aspell -a -c 2>&1`
+    fail('aspell failed: ' << output) unless $CHILD_STATUS.success?
+
+    lines = output.split("\n").select { |line| line =~ /^\&\s.+$/ }
+    misspellings = lines.map { |line| Misspelling.parse(original_name, line) }
+    misspellings.each { |m| puts m }
   end
 end


### PR DESCRIPTION
`aspelllint` was silently succeeding when `aspell` wasn't installed on a machine, which is a dangerous way to fail.

I tried to add a feature for this case (by setting `PATH` to a temp dir containing symlinks to `ruby` and `aspelllint`), but it seemed too brittle.  Any suggestions on that front would be appreciated.